### PR TITLE
moved colorjs.io to dependencies, added ESM and Node exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "autoprefixer": "^10.4.16",
         "babel-loader": "^9.1.3",
         "clean-webpack-plugin": "^4.0.0",
+        "colorjs.io": "^0.5.2",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
         "webpack-serve": "webpack serve --mode development --config webpack.config.js",
         "webpack-start": "webpack-dev-server --mode development --config webpack.config.js"
     },
+    "dependencies": {
+        "colorjs.io": "^0.5.2"
+    },
     "devDependencies": {
         "@babel/core": "^7.23.7",
         "@babel/preset-env": "^7.23.8",
@@ -65,7 +68,6 @@
         "autoprefixer": "^10.4.16",
         "babel-loader": "^9.1.3",
         "clean-webpack-plugin": "^4.0.0",
-        "colorjs.io": "^0.5.2",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",
@@ -96,7 +98,8 @@
     "exports": {
         ".": {
             "sass": "./scss/index.scss",
-            "typescript": "./ts/index.scss"
+            "import": "./js/index.js",
+            "require": "./js/index.js"
         }
     }
 }


### PR DESCRIPTION
to import hue_hex in a typescript project:
import { hue_hex} from "hue.gl";

package.json is missing export for typescript and ESM modules, exports block should read:
"exports": {
".": {
"sass": "./scss/index.scss",
remove ->> "typescript": "./ts/index.ts", <<-- NOTE: typescript is not a valid field
"import": "./js/index.js", // For ES Module imports
"require": "./js/index.js", // For CommonJS imports
}
(NB no comments allowed in json)

After editing package.json manually this error reveals itself when trying to import to import as above:

ERROR in ./node_modules/hue.gl/js/color/ColorSwatch.js 20:37-58
Module not found: Error: Can't resolve 'colorjs.io' in '/Projects/Starling/lib-graph/node_modules/hue.gl/js/color'
resolve 'colorjs.io' in '/Projects/Starling/lib-graph/node_modules/hue.gl/js/color'
Parsed request is a module
using description file: /Projects/Starling/lib-graph/node_modules/hue.gl/package.json (relative path: ./js/color)

FIX: Add colorjs.io as a dependency, to be bundled with library.